### PR TITLE
Fix windows pathing

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -45,7 +45,12 @@ export function getFlutterRoot(relativePath: boolean = true): string
 {
   let vscodeWorkspace = vscode.workspace.workspaceFolders![0].uri.path;
   let path = currentPath();
-
+	
+  // If platform is windows and path starts with / then remove the first slash
+  if (process.platform === "win32" && path.startsWith("/")) {
+    path = path.slice(1);
+    vscodeWorkspace = vscodeWorkspace.slice(1);
+  }
 
   while (path !== '/' && path !== '')
   {


### PR DESCRIPTION
In my case, every path started with /. For example: `/D:/Projects/flutterProject'. That resulted in "Flutter root not found" error. This is a simple fix and shouldn't break anything.