### PR TITLE
fix(runGenerationCommand): Update deprecated generate command

### DIFF
--- a/src/commands/extract-to-translation-file.ts
+++ b/src/commands/extract-to-translation-file.ts
@@ -203,7 +203,7 @@ async function runGenerationCommand()
     const outDir = pluginConfig.generatedKeyFileDir;
     const outFile = pluginConfig.generatedKeyFileName;
   
-    const command = `flutter pub run easy_localization:generate -f keys --source-dir ${sourceDir} --output-dir ${outDir} --output-file ${outFile}`;
+    const command = `dart run easy_localization:generate -f keys --source-dir ${sourceDir} --output-dir ${outDir} --output-file ${outFile}`;
   
     const flutterRoot = getFlutterRoot(false);
   


### PR DESCRIPTION
### Update deprecated generate command.

from:
https://github.com/iOSonntag/vscode-flutter-easylocalization/blob/2b5eb3f49d5806a04a3e64046b85954fefade059/src/commands/extract-to-translation-file.ts#L205-L207

to:
```
dart run easy_localization:generate -f keys --source-dir ${sourceDir} --output-dir ${outDir} --output-file ${outFile}
```
---
Output using `flutter pub run`:
```
Deprecated. Use `dart run` instead.
Package "easy_localization" is not an immediate dependency.
Cannot run executables in transitive dependencies.
```

Output using `dart run`:
```
Building package executable... 
Built easy_localization:generate.
All done! File generated in <workspace_location>/lib/generated/locale_keys.g.dart
```